### PR TITLE
Return query result references to WordEntry with static lifetime.

### DIFF
--- a/src/chinese_dictionary.rs
+++ b/src/chinese_dictionary.rs
@@ -57,7 +57,7 @@ pub fn init() {
 /// Query the dictionary specifically with English.
 /// Uses a largest first matching approach to look for compound words within the provided string.
 /// Will attempt to take the shortest of four tokens or the total number of tokens in the string to match against.
-pub fn query_by_english(raw: &str) -> Vec<&WordEntry> {
+pub fn query_by_english(raw: &str) -> Vec<&'static WordEntry> {
     let mut entries: Vec<&WordEntry> = Vec::new();
     let default_take = if raw.split(' ').count() < ENGLISH_MAX_LENGTH {
         raw.split(' ').count()
@@ -96,7 +96,7 @@ pub fn query_by_english(raw: &str) -> Vec<&WordEntry> {
 /// # Query by Pinyin
 /// Query the dictionary specifically with Pinyin.
 /// Uses space as a token delineator. Supports pinyin with no tones, tone marks, and tone numbers.
-pub fn query_by_pinyin(raw: &str) -> Vec<&WordEntry> {
+pub fn query_by_pinyin(raw: &str) -> Vec<&'static WordEntry> {
     let mut entries: Vec<&WordEntry> = Vec::new();
 
     for word in raw.split(' ') {
@@ -110,7 +110,7 @@ pub fn query_by_pinyin(raw: &str) -> Vec<&WordEntry> {
     entries
 }
 
-fn query_by_characters<'a>(dictionary: &'a Searchable, raw: &'a str) -> Vec<&'a WordEntry> {
+fn query_by_characters<'a>(dictionary: &'a Searchable, raw: &'a str) -> Vec<&'static WordEntry> {
     let mut entries: Vec<&WordEntry> = Vec::new();
 
     for word in tokenize(raw) {
@@ -127,7 +127,7 @@ fn query_by_characters<'a>(dictionary: &'a Searchable, raw: &'a str) -> Vec<&'a 
 /// # Query by Chinese
 /// Query the dictionary specifically with Chinese characters.
 /// Supports both Traditional and Simplified Chinese characters.
-pub fn query_by_chinese(raw: &str) -> Vec<&WordEntry> {
+pub fn query_by_chinese(raw: &str) -> Vec<&'static WordEntry> {
     match is_traditional(raw) {
         true => query_by_characters(&TRADITIONAL, raw),
         false => query_by_characters(&SIMPLIFIED, raw),
@@ -142,7 +142,7 @@ pub fn query_by_chinese(raw: &str) -> Vec<&WordEntry> {
 ///
 /// When querying using English, a largest first matching approached is used to look for compound words.
 /// Will attempt to take the shortest of four tokens or the total number of tokens in the string to match against.
-pub fn query(raw: &str) -> Option<Vec<&WordEntry>> {
+pub fn query(raw: &str) -> Option<Vec<&'static WordEntry>> {
     match chinese_detection::classify(raw) {
         ClassificationResult::EN => Some(query_by_english(raw)),
         ClassificationResult::PY => Some(query_by_pinyin(raw)),

--- a/src/chinese_dictionary.rs
+++ b/src/chinese_dictionary.rs
@@ -21,7 +21,7 @@ static DATA: Lazy<HashMap<u32, WordEntry>> =
     Lazy::new(|| deserialize_from(&include_bytes!("../data/data.dictionary")[..]).unwrap());
 static ENGLISH_MAX_LENGTH: usize = 4;
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct MeasureWord {
     pub traditional: String,
     pub simplified: String,
@@ -29,7 +29,7 @@ pub struct MeasureWord {
     pub pinyin_numbers: String,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct WordEntry {
     pub traditional: String,
     pub simplified: String,


### PR DESCRIPTION
Please consider looking at #8 first as it includes these changes and additional improvements.

Simple change to specify that the results of the various query functions return `'static` references to the `WordEntry`. Otherwise they are inferred with the same lifetime as the input `str` reference.

Closes #6 