### PR TITLE
Add query_by_chinese_exact  to query a single word in a specific dictionary.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,8 +92,8 @@ extern crate once_cell;
 mod chinese_dictionary;
 pub use self::chinese_dictionary::{
     classify, init, is_simplified, is_traditional, query, query_by_chinese, query_by_english,
-    query_by_pinyin, simplified_to_traditional, tokenize, traditional_to_simplified,
-    ClassificationResult, MeasureWord, WordEntry,
+    query_by_pinyin, query_by_simplified, query_by_traditional, simplified_to_traditional,
+    tokenize, traditional_to_simplified, ClassificationResult, MeasureWord, WordEntry,
 };
 
 #[cfg(test)]
@@ -142,6 +142,24 @@ mod tests {
         let result = query(text);
         let actual = result.unwrap().first().unwrap().english.first().unwrap();
         let expected = "dragon (as a decorative design)";
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_search_by_simplified_exact() {
+        let text = "龙纹";
+        let result = query_by_simplified(text);
+        let actual = result.first().unwrap().english.first().unwrap();
+        let expected = "dragon (as a decorative design)";
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_search_by_traditional_exact() {
+        let text = "繁體字";
+        let result = query_by_traditional(text);
+        let actual = result.first().unwrap().english.first().unwrap();
+        let expected = "traditional Chinese character";
         assert_eq!(expected, actual);
     }
 


### PR DESCRIPTION
Right now you can't really control what dictionary a lookup occurs in.
Since many characters exist in both Traditional and Simplified and the existing function tests for Traditional first, you will get the Traditional result in many cases.

This pull also refactors some code to avoid querying the tables twice. There shouldn't be an advantage to testing for the presence of a key and only then looking up the value, especially since it's only a `u32`. It probably doesn't make a huge different, but this does avoid hashing the string key twice.

This also includes the changes in #7. Closes #6.